### PR TITLE
Add Logic to not invalidate Access Keys if user belongs to a certain group

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+grunt/node_modules/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 grunt/node_modules/*
 lambda/build/*
+releases/*
+grunt/package.*.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 grunt/node_modules/*
+lambda/build/*

--- a/grunt/Gruntfile.js
+++ b/grunt/Gruntfile.js
@@ -34,6 +34,10 @@ module.exports = function(grunt) {
               replacement: '<%= pkg.key_disabler.email.report_to %>'
             },
             {
+              match: 'emailregion',
+              replacement: '<%= pkg.key_disabler.email.email_region %>'
+            },
+            {
               match: 'emailreportfrom',
               replacement: '<%= pkg.key_disabler.email.report_from %>'
             },

--- a/grunt/Gruntfile.js
+++ b/grunt/Gruntfile.js
@@ -25,6 +25,11 @@ module.exports = function(grunt) {
               replacement: '<%= pkg.key_disabler.iam.serviceaccount %>'
             },
             {
+              match: 'exclusiongroup',
+              replacement: '<%= pkg.key_disabler.iam.exclusiongroup %>'
+
+            },
+            {
               match: 'emailreportto',
               replacement: '<%= pkg.key_disabler.email.report_to %>'
             },

--- a/grunt/package.json
+++ b/grunt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "key_disabler",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Lambda helper functions",
   "main": "Gruntfile.js",
   "dependencies": {

--- a/grunt/package.json
+++ b/grunt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "key_disabler",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Lambda helper functions",
   "main": "Gruntfile.js",
   "dependencies": {
@@ -40,6 +40,7 @@
       }
     },
     "email": {
+      "email_region": "us-west-2",
       "report_to": "receipient@example.com",
       "report_from": "sender@example.com",
       "send_completion_report": "False"

--- a/grunt/package.json
+++ b/grunt/package.json
@@ -46,6 +46,7 @@
     },
     "iam": {
       "serviceaccount": "IAM_USERNAME_TO_EXCLUDE_IF_ANY",
+      "exclusiongroup":"group_name",
       "lambda": {
         "rolename": "LambdaAccessKeyRotationRole",
         "policyname": "LambdaAccessKeyRotationPolicy"

--- a/grunt/scripts/createLambdaAccessKeyRotationPolicy.sh
+++ b/grunt/scripts/createLambdaAccessKeyRotationPolicy.sh
@@ -40,6 +40,7 @@ if [[ $EXISTS -eq 0 ]]; then
               'Effect': 'Allow',
               'Action': [
                   'iam:ListUsers',
+                  'iam:ListGroupsForUser',
                   'iam:ListAccessKeys',
                   'iam:UpdateAccessKey'
               ],

--- a/lambda/src/RotateAccessKey.py
+++ b/lambda/src/RotateAccessKey.py
@@ -10,6 +10,7 @@ SERVICE_ACCOUNT_NAME = '@@serviceaccount'
 EMAIL_TO_ADMIN = '@@emailreportto'
 EMAIL_FROM = '@@emailreportfrom'
 EMAIL_SEND_COMPLETION_REPORT = ast.literal_eval('@@emailsendcompletionreport')
+GROUP_LIST = "@@exclusiongroup"
 
 # Length of mask over the IAM Access Key
 MASK_ACCESS_KEY_LENGTH = ast.literal_eval('@@maskaccesskeylength')
@@ -132,6 +133,21 @@ def lambda_handler(event, context):
         print 'user %s' % user
         username = users[user]
         print 'username %s' % username
+
+        # test is a user belongs to a specific list of groups. If they do, do not invalidate the access key
+        print "Test if the user belongs to the exclusion group"
+        user_groups = client.list_groups_for_user(UserName=username)
+        skip = False
+        for groupName in user_groups['Groups']:
+            if groupName['GroupName'] == GROUP_LIST:
+                print 'Detected that user belongs to ', GROUP_LIST
+                skip = True
+                continue
+
+        if skip:
+            print "Do invalidate Access Key"
+            continue
+
 
         # check to see if the current user is a special service account
         if username == SERVICE_ACCOUNT_NAME:

--- a/lambda/src/RotateAccessKey.py
+++ b/lambda/src/RotateAccessKey.py
@@ -6,6 +6,7 @@ import ast
 
 BUILD_VERSION = '@@buildversion'
 AWS_REGION = '@@deploymentregion'
+AWS_EMAIL_REGION = '@@emailregion'
 SERVICE_ACCOUNT_NAME = '@@serviceaccount'
 EMAIL_TO_ADMIN = '@@emailreportto'
 EMAIL_FROM = '@@emailreportfrom'
@@ -62,7 +63,7 @@ def key_age(key_created_date):
 
 
 def send_deactivate_email(email_to, username, age, access_key_id):
-    client = boto3.client('ses', region_name=AWS_REGION)
+    client = boto3.client('ses', region_name=AWS_EMAIL_REGION)
     response = client.send_email(
         Source=EMAIL_FROM,
         Destination={
@@ -81,7 +82,7 @@ def send_deactivate_email(email_to, username, age, access_key_id):
 
 
 def send_completion_email(email_to, finished, deactivated_report):
-    client = boto3.client('ses', region_name=AWS_REGION)
+    client = boto3.client('ses', region_name=AWS_EMAIL_REGION)
     response = client.send_email(
         Source=EMAIL_FROM,
         Destination={

--- a/readme.md
+++ b/readme.md
@@ -43,10 +43,12 @@ These instructions are for OSX. Your mileage may vary on Windows and other \*nix
 	1. Set the `aws_account_number` value to your AWS account id found on https://portal.aws.amazon.com/gp/aws/manageYourAccount
 	2. Set the `first_warning` and `last_warning` to the age that the key has to be in days to trigger a warning. These limits trigger an email send to `report_to`
 	3. Set the `expiry` to the age in days when the key expires. At this age the key is disabled and an email is triggered to `report_to` notifying this change
-	4. Set the `send_completion_report` value to `True` to enable email delivery via SES
-	5. Set the `report_to` value to the email address you'd like to receive deletion reports to
-	6. Set the `report_from` value to the email address you'd like to use as the sender address for deletion reports. Note that the domain for this needs to be verified in AWS SES.
-	7. Set the `deployment_region` to a region that supports Lambda and SES. Also ensure that the region has SES sandbox mode disabled.
+	4. Set the `serviceaccount` to the account username you want the script to ignore
+	5. Set the `exclusiongroup` to the name of a group assigned to users you want the script to ignore.
+	6. Set the `send_completion_report` value to `True` to enable email delivery via SES
+	7. Set the `report_to` value to the email address you'd like to receive deletion reports to
+	8. Set the `report_from` value to the email address you'd like to use as the sender address for deletion reports. Note that the domain for this needs to be verified in AWS SES.
+	9. Set the `deployment_region` to a region that supports Lambda and SES. Also ensure that the region has SES sandbox mode disabled.
 		* See the AWS Region table for support https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services/
 5. Ensure you can successfully connect to AWS from the CLI, eg run `aws iam get-user` to verify successful connection
 6. from the `/grunt` directory run `grunt bumpup && grunt deployLambda` to bump your version number and perform a build/deploy of the Lambda function to the selected region

--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,8 @@ These instructions are for OSX. Your mileage may vary on Windows and other \*nix
 	6. Set the `send_completion_report` value to `True` to enable email delivery via SES
 	7. Set the `report_to` value to the email address you'd like to receive deletion reports to
 	8. Set the `report_from` value to the email address you'd like to use as the sender address for deletion reports. Note that the domain for this needs to be verified in AWS SES.
-	9. Set the `deployment_region` to a region that supports Lambda and SES. Also ensure that the region has SES sandbox mode disabled.
+	9. Set the `deployment_region` to a region that supports Lambda. 
+	10 Set the `email_region` to the region that supports SES. Also ensure that the region has SES sandbox mode disabled.
 		* See the AWS Region table for support https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services/
 5. Ensure you can successfully connect to AWS from the CLI, eg run `aws iam get-user` to verify successful connection
 6. from the `/grunt` directory run `grunt bumpup && grunt deployLambda` to bump your version number and perform a build/deploy of the Lambda function to the selected region


### PR DESCRIPTION
Added an option to not invalidate Access Keys for users that belong to a nominated group.  The group can be an empty group, that can be assigned to a user, but just need to match a group name.

Made a change that allows the script to be deployed to Lambda in any region and also set the SES region.

